### PR TITLE
Make vhost-user-console run on macOS.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1927,7 +1927,19 @@ dependencies = [
  "libc",
  "uuid",
  "vm-memory",
- "vmm-sys-util",
+ "vmm-sys-util 0.14.0",
+]
+
+[[package]]
+name = "vhost"
+version = "0.14.0"
+source = "git+https://github.com/uran0sH/vhost?rev=54d673aa851f16c4828a6a661179de6c892a4ad8#54d673aa851f16c4828a6a661179de6c892a4ad8"
+dependencies = [
+ "bitflags 2.9.1",
+ "libc",
+ "uuid",
+ "vm-memory",
+ "vmm-sys-util 0.15.0",
 ]
 
 [[package]]
@@ -1941,12 +1953,12 @@ dependencies = [
  "queues",
  "socketcan",
  "thiserror 2.0.12",
- "vhost",
- "vhost-user-backend",
+ "vhost 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vhost-user-backend 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "virtio-bindings",
  "virtio-queue",
  "vm-memory",
- "vmm-sys-util",
+ "vmm-sys-util 0.14.0",
 ]
 
 [[package]]
@@ -1962,12 +1974,12 @@ dependencies = [
  "log",
  "queues",
  "thiserror 2.0.12",
- "vhost",
- "vhost-user-backend",
+ "vhost 0.14.0 (git+https://github.com/uran0sH/vhost?rev=54d673aa851f16c4828a6a661179de6c892a4ad8)",
+ "vhost-user-backend 0.20.0 (git+https://github.com/uran0sH/vhost?rev=54d673aa851f16c4828a6a661179de6c892a4ad8)",
  "virtio-bindings",
  "virtio-queue",
  "vm-memory",
- "vmm-sys-util",
+ "vmm-sys-util 0.15.0",
 ]
 
 [[package]]
@@ -1981,12 +1993,12 @@ dependencies = [
  "libgpiod",
  "log",
  "thiserror 2.0.12",
- "vhost",
- "vhost-user-backend",
+ "vhost 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vhost-user-backend 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "virtio-bindings",
  "virtio-queue",
  "vm-memory",
- "vmm-sys-util",
+ "vmm-sys-util 0.14.0",
 ]
 
 [[package]]
@@ -2004,12 +2016,12 @@ dependencies = [
  "rutabaga_gfx",
  "tempfile",
  "thiserror 2.0.12",
- "vhost",
- "vhost-user-backend",
+ "vhost 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vhost-user-backend 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "virtio-bindings",
  "virtio-queue",
  "vm-memory",
- "vmm-sys-util",
+ "vmm-sys-util 0.14.0",
 ]
 
 [[package]]
@@ -2022,12 +2034,12 @@ dependencies = [
  "libc",
  "log",
  "thiserror 2.0.12",
- "vhost",
- "vhost-user-backend",
+ "vhost 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vhost-user-backend 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "virtio-bindings",
  "virtio-queue",
  "vm-memory",
- "vmm-sys-util",
+ "vmm-sys-util 0.14.0",
 ]
 
 [[package]]
@@ -2045,12 +2057,12 @@ dependencies = [
  "rand",
  "tempfile",
  "thiserror 2.0.12",
- "vhost",
- "vhost-user-backend",
+ "vhost 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vhost-user-backend 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "virtio-bindings",
  "virtio-queue",
  "vm-memory",
- "vmm-sys-util",
+ "vmm-sys-util 0.14.0",
 ]
 
 [[package]]
@@ -2066,12 +2078,12 @@ dependencies = [
  "rand",
  "tempfile",
  "thiserror 2.0.12",
- "vhost",
- "vhost-user-backend",
+ "vhost 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vhost-user-backend 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "virtio-bindings",
  "virtio-queue",
  "vm-memory",
- "vmm-sys-util",
+ "vmm-sys-util 0.14.0",
 ]
 
 [[package]]
@@ -2084,12 +2096,12 @@ dependencies = [
  "itertools 0.14.0",
  "log",
  "thiserror 2.0.12",
- "vhost",
- "vhost-user-backend",
+ "vhost 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vhost-user-backend 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "virtio-bindings",
  "virtio-queue",
  "vm-memory",
- "vmm-sys-util",
+ "vmm-sys-util 0.14.0",
 ]
 
 [[package]]
@@ -2104,12 +2116,12 @@ dependencies = [
  "num_enum",
  "tempfile",
  "thiserror 2.0.12",
- "vhost",
- "vhost-user-backend",
+ "vhost 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vhost-user-backend 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "virtio-bindings",
  "virtio-queue",
  "vm-memory",
- "vmm-sys-util",
+ "vmm-sys-util 0.14.0",
 ]
 
 [[package]]
@@ -2126,12 +2138,12 @@ dependencies = [
  "rusty-fork",
  "tempfile",
  "thiserror 2.0.12",
- "vhost",
- "vhost-user-backend",
+ "vhost 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vhost-user-backend 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "virtio-bindings",
  "virtio-queue",
  "vm-memory",
- "vmm-sys-util",
+ "vmm-sys-util 0.14.0",
 ]
 
 [[package]]
@@ -2145,12 +2157,12 @@ dependencies = [
  "libc",
  "log",
  "thiserror 2.0.12",
- "vhost",
- "vhost-user-backend",
+ "vhost 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vhost-user-backend 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "virtio-bindings",
  "virtio-queue",
  "vm-memory",
- "vmm-sys-util",
+ "vmm-sys-util 0.14.0",
 ]
 
 [[package]]
@@ -2163,12 +2175,12 @@ dependencies = [
  "libc",
  "log",
  "thiserror 2.0.12",
- "vhost",
- "vhost-user-backend",
+ "vhost 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vhost-user-backend 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "virtio-bindings",
  "virtio-queue",
  "vm-memory",
- "vmm-sys-util",
+ "vmm-sys-util 0.14.0",
 ]
 
 [[package]]
@@ -2186,13 +2198,13 @@ dependencies = [
  "serde",
  "tempfile",
  "thiserror 2.0.12",
- "vhost",
- "vhost-user-backend",
+ "vhost 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vhost-user-backend 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "virtio-bindings",
  "virtio-queue",
  "virtio-vsock",
  "vm-memory",
- "vmm-sys-util",
+ "vmm-sys-util 0.14.0",
  "vsock",
 ]
 
@@ -2204,11 +2216,27 @@ checksum = "e183205a9ba7cb9c47fcb0fc0a07fc295a110efbb11ab78ad0d793b0a38a7bde"
 dependencies = [
  "libc",
  "log",
- "vhost",
+ "vhost 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "virtio-bindings",
  "virtio-queue",
  "vm-memory",
- "vmm-sys-util",
+ "vmm-sys-util 0.14.0",
+]
+
+[[package]]
+name = "vhost-user-backend"
+version = "0.20.0"
+source = "git+https://github.com/uran0sH/vhost?rev=54d673aa851f16c4828a6a661179de6c892a4ad8#54d673aa851f16c4828a6a661179de6c892a4ad8"
+dependencies = [
+ "bitflags 2.9.1",
+ "libc",
+ "log",
+ "mio",
+ "vhost 0.14.0 (git+https://github.com/uran0sH/vhost?rev=54d673aa851f16c4828a6a661179de6c892a4ad8)",
+ "virtio-bindings",
+ "virtio-queue",
+ "vm-memory",
+ "vmm-sys-util 0.15.0",
 ]
 
 [[package]]
@@ -2226,7 +2254,7 @@ dependencies = [
  "log",
  "virtio-bindings",
  "vm-memory",
- "vmm-sys-util",
+ "vmm-sys-util 0.14.0",
 ]
 
 [[package]]
@@ -2250,7 +2278,7 @@ dependencies = [
  "bitflags 2.9.1",
  "libc",
  "thiserror 1.0.69",
- "vmm-sys-util",
+ "vmm-sys-util 0.14.0",
  "winapi",
 ]
 
@@ -2259,6 +2287,16 @@ name = "vmm-sys-util"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d21f366bf22bfba3e868349978766a965cbe628c323d58e026be80b8357ab789"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+]
+
+[[package]]
+name = "vmm-sys-util"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "506c62fdf617a5176827c2f9afbcf1be155b03a9b4bf9617a60dbc07e3a1642f"
 dependencies = [
  "bitflags 1.3.2",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1926,19 +1926,19 @@ dependencies = [
  "bitflags 2.9.1",
  "libc",
  "uuid",
- "vm-memory",
+ "vm-memory 0.16.2",
  "vmm-sys-util 0.14.0",
 ]
 
 [[package]]
 name = "vhost"
 version = "0.14.0"
-source = "git+https://github.com/uran0sH/vhost?rev=54d673aa851f16c4828a6a661179de6c892a4ad8#54d673aa851f16c4828a6a661179de6c892a4ad8"
+source = "git+https://github.com/uran0sH/vhost?rev=a037c1bf7363ffa78d24065e88fbfdb72738f286#a037c1bf7363ffa78d24065e88fbfdb72738f286"
 dependencies = [
  "bitflags 2.9.1",
  "libc",
  "uuid",
- "vm-memory",
+ "vm-memory 0.16.1",
  "vmm-sys-util 0.15.0",
 ]
 
@@ -1955,9 +1955,9 @@ dependencies = [
  "thiserror 2.0.12",
  "vhost 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "vhost-user-backend 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "virtio-bindings",
- "virtio-queue",
- "vm-memory",
+ "virtio-bindings 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "virtio-queue 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vm-memory 0.16.2",
  "vmm-sys-util 0.14.0",
 ]
 
@@ -1970,15 +1970,15 @@ dependencies = [
  "console",
  "crossterm",
  "env_logger",
- "epoll",
  "log",
+ "mio",
  "queues",
  "thiserror 2.0.12",
- "vhost 0.14.0 (git+https://github.com/uran0sH/vhost?rev=54d673aa851f16c4828a6a661179de6c892a4ad8)",
- "vhost-user-backend 0.20.0 (git+https://github.com/uran0sH/vhost?rev=54d673aa851f16c4828a6a661179de6c892a4ad8)",
- "virtio-bindings",
- "virtio-queue",
- "vm-memory",
+ "vhost 0.14.0 (git+https://github.com/uran0sH/vhost?rev=a037c1bf7363ffa78d24065e88fbfdb72738f286)",
+ "vhost-user-backend 0.20.0 (git+https://github.com/uran0sH/vhost?rev=a037c1bf7363ffa78d24065e88fbfdb72738f286)",
+ "virtio-bindings 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "virtio-queue 0.16.0 (git+https://github.com/uran0sh/vm-virtio?branch=update-vm-memory)",
+ "vm-memory 0.16.1",
  "vmm-sys-util 0.15.0",
 ]
 
@@ -1995,9 +1995,9 @@ dependencies = [
  "thiserror 2.0.12",
  "vhost 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "vhost-user-backend 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "virtio-bindings",
- "virtio-queue",
- "vm-memory",
+ "virtio-bindings 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "virtio-queue 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vm-memory 0.16.2",
  "vmm-sys-util 0.14.0",
 ]
 
@@ -2018,9 +2018,9 @@ dependencies = [
  "thiserror 2.0.12",
  "vhost 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "vhost-user-backend 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "virtio-bindings",
- "virtio-queue",
- "vm-memory",
+ "virtio-bindings 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "virtio-queue 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vm-memory 0.16.2",
  "vmm-sys-util 0.14.0",
 ]
 
@@ -2036,9 +2036,9 @@ dependencies = [
  "thiserror 2.0.12",
  "vhost 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "vhost-user-backend 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "virtio-bindings",
- "virtio-queue",
- "vm-memory",
+ "virtio-bindings 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "virtio-queue 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vm-memory 0.16.2",
  "vmm-sys-util 0.14.0",
 ]
 
@@ -2059,9 +2059,9 @@ dependencies = [
  "thiserror 2.0.12",
  "vhost 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "vhost-user-backend 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "virtio-bindings",
- "virtio-queue",
- "vm-memory",
+ "virtio-bindings 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "virtio-queue 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vm-memory 0.16.2",
  "vmm-sys-util 0.14.0",
 ]
 
@@ -2080,9 +2080,9 @@ dependencies = [
  "thiserror 2.0.12",
  "vhost 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "vhost-user-backend 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "virtio-bindings",
- "virtio-queue",
- "vm-memory",
+ "virtio-bindings 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "virtio-queue 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vm-memory 0.16.2",
  "vmm-sys-util 0.14.0",
 ]
 
@@ -2098,9 +2098,9 @@ dependencies = [
  "thiserror 2.0.12",
  "vhost 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "vhost-user-backend 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "virtio-bindings",
- "virtio-queue",
- "vm-memory",
+ "virtio-bindings 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "virtio-queue 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vm-memory 0.16.2",
  "vmm-sys-util 0.14.0",
 ]
 
@@ -2118,9 +2118,9 @@ dependencies = [
  "thiserror 2.0.12",
  "vhost 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "vhost-user-backend 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "virtio-bindings",
- "virtio-queue",
- "vm-memory",
+ "virtio-bindings 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "virtio-queue 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vm-memory 0.16.2",
  "vmm-sys-util 0.14.0",
 ]
 
@@ -2140,9 +2140,9 @@ dependencies = [
  "thiserror 2.0.12",
  "vhost 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "vhost-user-backend 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "virtio-bindings",
- "virtio-queue",
- "vm-memory",
+ "virtio-bindings 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "virtio-queue 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vm-memory 0.16.2",
  "vmm-sys-util 0.14.0",
 ]
 
@@ -2159,9 +2159,9 @@ dependencies = [
  "thiserror 2.0.12",
  "vhost 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "vhost-user-backend 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "virtio-bindings",
- "virtio-queue",
- "vm-memory",
+ "virtio-bindings 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "virtio-queue 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vm-memory 0.16.2",
  "vmm-sys-util 0.14.0",
 ]
 
@@ -2177,9 +2177,9 @@ dependencies = [
  "thiserror 2.0.12",
  "vhost 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "vhost-user-backend 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "virtio-bindings",
- "virtio-queue",
- "vm-memory",
+ "virtio-bindings 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "virtio-queue 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vm-memory 0.16.2",
  "vmm-sys-util 0.14.0",
 ]
 
@@ -2200,10 +2200,10 @@ dependencies = [
  "thiserror 2.0.12",
  "vhost 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "vhost-user-backend 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "virtio-bindings",
- "virtio-queue",
+ "virtio-bindings 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "virtio-queue 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "virtio-vsock",
- "vm-memory",
+ "vm-memory 0.16.2",
  "vmm-sys-util 0.14.0",
  "vsock",
 ]
@@ -2217,25 +2217,25 @@ dependencies = [
  "libc",
  "log",
  "vhost 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "virtio-bindings",
- "virtio-queue",
- "vm-memory",
+ "virtio-bindings 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "virtio-queue 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vm-memory 0.16.2",
  "vmm-sys-util 0.14.0",
 ]
 
 [[package]]
 name = "vhost-user-backend"
 version = "0.20.0"
-source = "git+https://github.com/uran0sH/vhost?rev=54d673aa851f16c4828a6a661179de6c892a4ad8#54d673aa851f16c4828a6a661179de6c892a4ad8"
+source = "git+https://github.com/uran0sH/vhost?rev=a037c1bf7363ffa78d24065e88fbfdb72738f286#a037c1bf7363ffa78d24065e88fbfdb72738f286"
 dependencies = [
  "bitflags 2.9.1",
  "libc",
  "log",
  "mio",
- "vhost 0.14.0 (git+https://github.com/uran0sH/vhost?rev=54d673aa851f16c4828a6a661179de6c892a4ad8)",
- "virtio-bindings",
- "virtio-queue",
- "vm-memory",
+ "vhost 0.14.0 (git+https://github.com/uran0sH/vhost?rev=a037c1bf7363ffa78d24065e88fbfdb72738f286)",
+ "virtio-bindings 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "virtio-queue 0.16.0 (git+https://github.com/uran0sh/vm-virtio?branch=update-vm-memory)",
+ "vm-memory 0.16.1",
  "vmm-sys-util 0.15.0",
 ]
 
@@ -2246,14 +2246,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "804f498a26d5a63be7bbb8bdcd3869c3f286c4c4a17108905276454da0caf8cb"
 
 [[package]]
+name = "virtio-bindings"
+version = "0.2.6"
+source = "git+https://github.com/uran0sh/vm-virtio?branch=update-vm-memory#9f91e13a2d29c98e539e94eb8dfb15e53b429642"
+
+[[package]]
 name = "virtio-queue"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb0479158f863e59323771a1f684d843962f76960b86fecfec2bfa9c8f0f9180"
 dependencies = [
  "log",
- "virtio-bindings",
- "vm-memory",
+ "virtio-bindings 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vm-memory 0.16.2",
+ "vmm-sys-util 0.14.0",
+]
+
+[[package]]
+name = "virtio-queue"
+version = "0.16.0"
+source = "git+https://github.com/uran0sh/vm-virtio?branch=update-vm-memory#9f91e13a2d29c98e539e94eb8dfb15e53b429642"
+dependencies = [
+ "libc",
+ "log",
+ "virtio-bindings 0.2.6 (git+https://github.com/uran0sh/vm-virtio?branch=update-vm-memory)",
+ "vm-memory 0.16.1",
  "vmm-sys-util 0.14.0",
 ]
 
@@ -2263,9 +2280,22 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e49ff39d455ce92f01a910cb11b01e54b61c6f3b5d308a144c86044b39955b79"
 dependencies = [
- "virtio-bindings",
- "virtio-queue",
- "vm-memory",
+ "virtio-bindings 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "virtio-queue 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vm-memory 0.16.2",
+]
+
+[[package]]
+name = "vm-memory"
+version = "0.16.1"
+source = "git+https://github.com/rust-vmm/vm-memory?rev=b2eaf989de2c3b9146ea7625250472501cd793fd#b2eaf989de2c3b9146ea7625250472501cd793fd"
+dependencies = [
+ "arc-swap",
+ "bitflags 2.9.1",
+ "libc",
+ "thiserror 1.0.69",
+ "vmm-sys-util 0.12.1",
+ "winapi",
 ]
 
 [[package]]
@@ -2280,6 +2310,16 @@ dependencies = [
  "thiserror 1.0.69",
  "vmm-sys-util 0.14.0",
  "winapi",
+]
+
+[[package]]
+name = "vmm-sys-util"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1435039746e20da4f8d507a72ee1b916f7b4b05af7a91c093d2c6561934ede"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
 ]
 
 [[package]]

--- a/vhost-device-console/Cargo.toml
+++ b/vhost-device-console/Cargo.toml
@@ -22,18 +22,18 @@ clap = { version = "4.5",  features = ["derive"] }
 env_logger = "0.11"
 log = "0.4"
 thiserror = "2.0"
-vhost = { git = "https://github.com/uran0sH/vhost", rev = "54d673aa851f16c4828a6a661179de6c892a4ad8", features = ["vhost-user-backend"] }
-vhost-user-backend = { git = "https://github.com/uran0sH/vhost", rev = "54d673aa851f16c4828a6a661179de6c892a4ad8" }
+vhost = { git = "https://github.com/uran0sH/vhost", rev = "a037c1bf7363ffa78d24065e88fbfdb72738f286", features = ["vhost-user-backend"] }
+vhost-user-backend = { git = "https://github.com/uran0sH/vhost", rev = "a037c1bf7363ffa78d24065e88fbfdb72738f286" }
 virtio-bindings = "0.2.5"
-virtio-queue = "0.16"
-vm-memory = "0.16.1"
+virtio-queue = { git = "https://github.com/uran0sh/vm-virtio", branch = "update-vm-memory" }
+vm-memory = { git = "https://github.com/rust-vmm/vm-memory", rev = "b2eaf989de2c3b9146ea7625250472501cd793fd" }
 vmm-sys-util = "0.15"
 mio = { version = "1.0.4", features = ["os-poll", "os-ext"] }
 
 [dev-dependencies]
 assert_matches = "1.5"
-virtio-queue = { version = "0.16", features = ["test-utils"] }
-vm-memory = { version = "0.16.1", features = ["backend-mmap", "backend-atomic"] }
+virtio-queue = { git = "https://github.com/uran0sh/vm-virtio", branch = "update-vm-memory", features= ["test-utils"] }
+vm-memory = { git = "https://github.com/rust-vmm/vm-memory", rev = "b2eaf989de2c3b9146ea7625250472501cd793fd", features = ["backend-mmap", "backend-atomic"] }
 
 [lints]
 workspace = true

--- a/vhost-device-console/Cargo.toml
+++ b/vhost-device-console/Cargo.toml
@@ -20,7 +20,6 @@ crossterm = "0.29.0"
 queues = "1.0.2"
 clap = { version = "4.5",  features = ["derive"] }
 env_logger = "0.11"
-epoll = "4.3"
 log = "0.4"
 thiserror = "2.0"
 vhost = { git = "https://github.com/uran0sH/vhost", rev = "54d673aa851f16c4828a6a661179de6c892a4ad8", features = ["vhost-user-backend"] }
@@ -29,6 +28,7 @@ virtio-bindings = "0.2.5"
 virtio-queue = "0.16"
 vm-memory = "0.16.1"
 vmm-sys-util = "0.15"
+mio = { version = "1.0.4", features = ["os-poll", "os-ext"] }
 
 [dev-dependencies]
 assert_matches = "1.5"

--- a/vhost-device-console/Cargo.toml
+++ b/vhost-device-console/Cargo.toml
@@ -23,12 +23,12 @@ env_logger = "0.11"
 epoll = "4.3"
 log = "0.4"
 thiserror = "2.0"
-vhost = { version = "0.14", features = ["vhost-user-backend"] }
-vhost-user-backend = "0.20"
+vhost = { git = "https://github.com/uran0sH/vhost", rev = "54d673aa851f16c4828a6a661179de6c892a4ad8", features = ["vhost-user-backend"] }
+vhost-user-backend = { git = "https://github.com/uran0sH/vhost", rev = "54d673aa851f16c4828a6a661179de6c892a4ad8" }
 virtio-bindings = "0.2.5"
 virtio-queue = "0.16"
 vm-memory = "0.16.1"
-vmm-sys-util = "0.14"
+vmm-sys-util = "0.15"
 
 [dev-dependencies]
 assert_matches = "1.5"

--- a/vhost-device-console/src/vhu_console.rs
+++ b/vhost-device-console/src/vhu_console.rs
@@ -10,11 +10,12 @@ use std::{
     net::TcpListener,
     os::fd::{AsRawFd, RawFd},
     slice::from_raw_parts,
-    sync::{Arc, RwLock},
+    sync::{Arc, Mutex, RwLock},
 };
 
 use crossterm::terminal::{disable_raw_mode, enable_raw_mode};
 use log::{error, trace, warn};
+use mio::{unix::SourceFd, Interest, Poll, Token};
 use queues::{IsQueue, Queue};
 use thiserror::Error as ThisError;
 use vhost::vhost_user::message::{VhostUserProtocolFeatures, VhostUserVirtioFeatures};
@@ -28,7 +29,8 @@ use vm_memory::{
     ByteValued, GuestAddressSpace, GuestMemoryAtomic, GuestMemoryLoadGuard, GuestMemoryMmap,
 };
 use vmm_sys_util::{
-    event::{new_event_consumer_and_notifier, EventConsumer, EventFlag, EventNotifier}, eventfd::{EventFd, EFD_NONBLOCK}
+    event::{new_event_consumer_and_notifier, EventConsumer, EventFlag, EventNotifier},
+    eventfd::{EventFd, EFD_NONBLOCK},
 };
 
 use crate::{
@@ -129,7 +131,7 @@ pub struct VhostUserConsoleBackend {
     event_idx: bool,
     rx_ctrl_fifo: Queue<VirtioConsoleControl>,
     rx_data_fifo: Queue<u8>,
-    epoll_fd: i32,
+    epoll_fd: Mutex<Poll>,
     stream_fd: Option<i32>,
     pub ready: bool,
     pub ready_to_write: bool,
@@ -150,13 +152,14 @@ impl VhostUserConsoleBackend {
     pub const NUM_QUEUES: u16 = 4;
 
     pub fn new(max_queue_size: usize, controller: Arc<RwLock<ConsoleController>>) -> Result<Self> {
+        let poller = Poll::new().unwrap();
         Ok(Self {
             max_queue_size,
             controller,
             event_idx: false,
             rx_ctrl_fifo: Queue::new(),
             rx_data_fifo: Queue::new(),
-            epoll_fd: epoll::create(false).map_err(|_| Error::EpollFdCreate)?,
+            epoll_fd: Mutex::new(poller),
             stream_fd: None,
             acked_features: 0x0,
             ready: false,
@@ -167,7 +170,8 @@ impl VhostUserConsoleBackend {
             listener: None,
             rx_event: EventFd::new(EFD_NONBLOCK).map_err(|_| Error::EventFdFailed)?,
             rx_ctrl_event: EventFd::new(EFD_NONBLOCK).map_err(|_| Error::EventFdFailed)?,
-            exit_event: new_event_consumer_and_notifier(EventFlag::NONBLOCK).map_err(|_| Error::EventFdFailed)?,
+            exit_event: new_event_consumer_and_notifier(EventFlag::NONBLOCK)
+                .map_err(|_| Error::EventFdFailed)?,
             mem: None,
         })
     }
@@ -181,7 +185,7 @@ impl VhostUserConsoleBackend {
             let stdin: Box<dyn Read + Send + Sync> = Box::new(io::stdin());
             self.stdin = Some(stdin);
 
-            Self::epoll_register(self.epoll_fd.as_raw_fd(), stdin_fd, epoll::Events::EPOLLIN)
+            self.epoll_register(stdin_fd, Interest::READABLE)
                 .map_err(|_| Error::EpollAdd)?;
         } else {
             let listener = TcpListener::bind(tcpaddr_str).expect("asdasd");
@@ -523,9 +527,13 @@ impl VhostUserConsoleBackend {
             )
             .unwrap();
 
-        let epoll_fd = self.epoll_fd.as_raw_fd();
+        let epoll_fd = self.epoll_fd.lock().unwrap().as_raw_fd();
         vring_worker
-            .register_listener(epoll_fd, EventSet::READABLE, u64::from(QueueEvents::KEY_EFD))
+            .register_listener(
+                epoll_fd,
+                EventSet::READABLE,
+                u64::from(QueueEvents::KEY_EFD),
+            )
             .unwrap();
 
         if self.controller.read().unwrap().backend == BackendType::Network {
@@ -541,27 +549,38 @@ impl VhostUserConsoleBackend {
     }
 
     /// Register a file with an epoll to listen for events in evset.
-    pub fn epoll_register(epoll_fd: RawFd, fd: RawFd, evset: epoll::Events) -> Result<()> {
-        epoll::ctl(
-            epoll_fd,
-            epoll::ControlOptions::EPOLL_CTL_ADD,
-            fd,
-            epoll::Event::new(evset, fd as u64),
-        )
-        .map_err(|_| Error::EpollAdd)?;
+    pub fn epoll_register(&self, fd: RawFd, evset: Interest) -> Result<()> {
+        // epoll::ctl(
+        //     epoll_fd,
+        //     epoll::ControlOptions::EPOLL_CTL_ADD,
+        //     fd,
+        //     epoll::Event::new(evset, fd as u64),
+        // )
+        // .map_err(|_| Error::EpollAdd)?;
+        self.epoll_fd
+            .lock()
+            .unwrap()
+            .registry()
+            .register(&mut SourceFd(&fd), Token(fd as usize), evset)
+            .map_err(|_| Error::EpollAdd)?;
         Ok(())
     }
 
     /// Remove a file from the epoll.
-    pub fn epoll_unregister(epoll_fd: RawFd, fd: RawFd) -> Result<()> {
-        epoll::ctl(
-            epoll_fd,
-            epoll::ControlOptions::EPOLL_CTL_DEL,
-            fd,
-            epoll::Event::new(epoll::Events::empty(), 0),
-        )
-        .map_err(|_| Error::EpollRemove)?;
-
+    pub fn epoll_unregister(&self, fd: RawFd) -> Result<()> {
+        // epoll::ctl(
+        //     epoll_fd,
+        //     epoll::ControlOptions::EPOLL_CTL_DEL,
+        //     fd,
+        //     epoll::Event::new(epoll::Events::empty(), 0),
+        // )
+        // .map_err(|_| Error::EpollRemove)?;
+        self.epoll_fd
+            .lock()
+            .unwrap()
+            .registry()
+            .deregister(&mut SourceFd(&fd))
+            .map_err(|_| Error::EpollRemove)?;
         Ok(())
     }
 
@@ -579,11 +598,7 @@ impl VhostUserConsoleBackend {
                     println!("New connection on: {local_addr}");
                     let stream_raw_fd = stream.as_raw_fd();
                     self.stream_fd = Some(stream_raw_fd);
-                    if let Err(err) = Self::epoll_register(
-                        self.epoll_fd.as_raw_fd(),
-                        stream_raw_fd,
-                        epoll::Events::EPOLLIN,
-                    ) {
+                    if let Err(err) = self.epoll_register(stream_raw_fd, Interest::READABLE) {
                         warn!("Failed to register with epoll: {err:?}");
                     }
 
@@ -631,10 +646,7 @@ impl VhostUserConsoleBackend {
                         .local_addr()
                         .unwrap();
                     println!("Close connection on: {local_addr}");
-                    if let Err(err) = Self::epoll_unregister(
-                        self.epoll_fd.as_raw_fd(),
-                        self.stream_fd.expect("No stream fd"),
-                    ) {
+                    if let Err(err) = self.epoll_unregister(self.stream_fd.expect("No stream fd")) {
                         warn!("Failed to register with epoll: {err:?}");
                     }
                     return;
@@ -914,15 +926,30 @@ mod tests {
             .unwrap();
 
         vu_console_backend
-            .handle_event(QueueEvents::CTRL_RX_QUEUE, EventSet::READABLE, &list_vrings, 0)
+            .handle_event(
+                QueueEvents::CTRL_RX_QUEUE,
+                EventSet::READABLE,
+                &list_vrings,
+                0,
+            )
             .unwrap();
 
         vu_console_backend
-            .handle_event(QueueEvents::CTRL_TX_QUEUE, EventSet::READABLE, &list_vrings, 0)
+            .handle_event(
+                QueueEvents::CTRL_TX_QUEUE,
+                EventSet::READABLE,
+                &list_vrings,
+                0,
+            )
             .unwrap();
 
         vu_console_backend
-            .handle_event(QueueEvents::BACKEND_RX_EFD, EventSet::READABLE, &list_vrings, 0)
+            .handle_event(
+                QueueEvents::BACKEND_RX_EFD,
+                EventSet::READABLE,
+                &list_vrings,
+                0,
+            )
             .unwrap();
 
         vu_console_backend

--- a/vhost-device-console/src/vhu_console.rs
+++ b/vhost-device-console/src/vhu_console.rs
@@ -18,7 +18,7 @@ use log::{error, trace, warn};
 use queues::{IsQueue, Queue};
 use thiserror::Error as ThisError;
 use vhost::vhost_user::message::{VhostUserProtocolFeatures, VhostUserVirtioFeatures};
-use vhost_user_backend::{VhostUserBackendMut, VringEpollHandler, VringRwLock, VringT};
+use vhost_user_backend::{EventSet, VhostUserBackendMut, VringEpollHandler, VringRwLock, VringT};
 use virtio_bindings::bindings::{
     virtio_config::{VIRTIO_F_NOTIFY_ON_EMPTY, VIRTIO_F_VERSION_1},
     virtio_ring::{VIRTIO_RING_F_EVENT_IDX, VIRTIO_RING_F_INDIRECT_DESC},
@@ -28,8 +28,7 @@ use vm_memory::{
     ByteValued, GuestAddressSpace, GuestMemoryAtomic, GuestMemoryLoadGuard, GuestMemoryMmap,
 };
 use vmm_sys_util::{
-    epoll::EventSet,
-    eventfd::{EventFd, EFD_NONBLOCK},
+    event::{new_event_consumer_and_notifier, EventConsumer, EventFlag, EventNotifier}, eventfd::{EventFd, EFD_NONBLOCK}
 };
 
 use crate::{
@@ -140,7 +139,7 @@ pub struct VhostUserConsoleBackend {
     pub stream: Option<Box<dyn ReadWrite + Send + Sync>>,
     pub rx_event: EventFd,
     pub rx_ctrl_event: EventFd,
-    pub exit_event: EventFd,
+    pub exit_event: (EventConsumer, EventNotifier),
     mem: Option<GuestMemoryAtomic<GuestMemoryMmap>>,
 }
 
@@ -168,7 +167,7 @@ impl VhostUserConsoleBackend {
             listener: None,
             rx_event: EventFd::new(EFD_NONBLOCK).map_err(|_| Error::EventFdFailed)?,
             rx_ctrl_event: EventFd::new(EFD_NONBLOCK).map_err(|_| Error::EventFdFailed)?,
-            exit_event: EventFd::new(EFD_NONBLOCK).map_err(|_| Error::EventFdFailed)?,
+            exit_event: new_event_consumer_and_notifier(EventFlag::NONBLOCK).map_err(|_| Error::EventFdFailed)?,
             mem: None,
         })
     }
@@ -501,7 +500,7 @@ impl VhostUserConsoleBackend {
         vring_worker
             .register_listener(
                 rx_event_fd,
-                EventSet::IN,
+                EventSet::READABLE,
                 u64::from(QueueEvents::BACKEND_RX_EFD),
             )
             .unwrap();
@@ -510,23 +509,23 @@ impl VhostUserConsoleBackend {
         vring_worker
             .register_listener(
                 rx_ctrl_event_fd,
-                EventSet::IN,
+                EventSet::READABLE,
                 u64::from(QueueEvents::BACKEND_CTRL_RX_EFD),
             )
             .unwrap();
 
-        let exit_event_fd = self.exit_event.as_raw_fd();
+        let exit_event_fd = self.exit_event.0.as_raw_fd();
         vring_worker
             .register_listener(
                 exit_event_fd,
-                EventSet::IN,
+                EventSet::READABLE,
                 u64::from(QueueEvents::EXIT_EFD),
             )
             .unwrap();
 
         let epoll_fd = self.epoll_fd.as_raw_fd();
         vring_worker
-            .register_listener(epoll_fd, EventSet::IN, u64::from(QueueEvents::KEY_EFD))
+            .register_listener(epoll_fd, EventSet::READABLE, u64::from(QueueEvents::KEY_EFD))
             .unwrap();
 
         if self.controller.read().unwrap().backend == BackendType::Network {
@@ -534,7 +533,7 @@ impl VhostUserConsoleBackend {
             vring_worker
                 .register_listener(
                     listener_fd,
-                    EventSet::IN,
+                    EventSet::READABLE,
                     u64::from(QueueEvents::LISTENER_EFD),
                 )
                 .unwrap();
@@ -850,8 +849,13 @@ impl VhostUserBackendMut for VhostUserConsoleBackend {
         Ok(())
     }
 
-    fn exit_event(&self, _thread_index: usize) -> Option<EventFd> {
-        self.exit_event.try_clone().ok()
+    fn exit_event(&self, _thread_index: usize) -> Option<(EventConsumer, EventNotifier)> {
+        let consumer = self.exit_event.0.try_clone().ok();
+        let notifier = self.exit_event.1.try_clone().ok();
+        match (consumer, notifier) {
+            (Some(c), Some(n)) => Some((c, n)),
+            _ => None,
+        }
     }
 }
 
@@ -902,29 +906,29 @@ mod tests {
         let list_vrings = [vring.clone(), vring.clone(), vring.clone(), vring];
 
         vu_console_backend
-            .handle_event(QueueEvents::RX_QUEUE, EventSet::IN, &list_vrings, 0)
+            .handle_event(QueueEvents::RX_QUEUE, EventSet::READABLE, &list_vrings, 0)
             .unwrap();
 
         vu_console_backend
-            .handle_event(QueueEvents::TX_QUEUE, EventSet::IN, &list_vrings, 0)
+            .handle_event(QueueEvents::TX_QUEUE, EventSet::READABLE, &list_vrings, 0)
             .unwrap();
 
         vu_console_backend
-            .handle_event(QueueEvents::CTRL_RX_QUEUE, EventSet::IN, &list_vrings, 0)
+            .handle_event(QueueEvents::CTRL_RX_QUEUE, EventSet::READABLE, &list_vrings, 0)
             .unwrap();
 
         vu_console_backend
-            .handle_event(QueueEvents::CTRL_TX_QUEUE, EventSet::IN, &list_vrings, 0)
+            .handle_event(QueueEvents::CTRL_TX_QUEUE, EventSet::READABLE, &list_vrings, 0)
             .unwrap();
 
         vu_console_backend
-            .handle_event(QueueEvents::BACKEND_RX_EFD, EventSet::IN, &list_vrings, 0)
+            .handle_event(QueueEvents::BACKEND_RX_EFD, EventSet::READABLE, &list_vrings, 0)
             .unwrap();
 
         vu_console_backend
             .handle_event(
                 QueueEvents::BACKEND_CTRL_RX_EFD,
-                EventSet::IN,
+                EventSet::READABLE,
                 &list_vrings,
                 0,
             )
@@ -1368,7 +1372,7 @@ mod tests {
 
         vu_console_backend.ready_to_write = true;
         vu_console_backend
-            .handle_event(QueueEvents::KEY_EFD, EventSet::IN, &[vring], 0)
+            .handle_event(QueueEvents::KEY_EFD, EventSet::READABLE, &[vring], 0)
             .unwrap();
 
         let received_byte = vu_console_backend.rx_data_fifo.peek();
@@ -1398,7 +1402,7 @@ mod tests {
 
         vu_console_backend.ready_to_write = true;
         vu_console_backend
-            .handle_event(QueueEvents::KEY_EFD, EventSet::IN, &[vring], 0)
+            .handle_event(QueueEvents::KEY_EFD, EventSet::READABLE, &[vring], 0)
             .unwrap();
 
         let received_byte = vu_console_backend.rx_data_fifo.peek();

--- a/vhost-device-console/src/vhu_console.rs
+++ b/vhost-device-console/src/vhu_console.rs
@@ -28,9 +28,8 @@ use virtio_queue::{DescriptorChain, QueueOwnedT};
 use vm_memory::{
     ByteValued, GuestAddressSpace, GuestMemoryAtomic, GuestMemoryLoadGuard, GuestMemoryMmap,
 };
-use vmm_sys_util::{
-    event::{new_event_consumer_and_notifier, EventConsumer, EventFlag, EventNotifier},
-    eventfd::{EventFd, EFD_NONBLOCK},
+use vmm_sys_util::event::{
+    new_event_consumer_and_notifier, EventConsumer, EventFlag, EventNotifier,
 };
 
 use crate::{
@@ -139,8 +138,8 @@ pub struct VhostUserConsoleBackend {
     pub stdin: Option<Box<dyn Read + Send + Sync>>,
     pub listener: Option<TcpListener>,
     pub stream: Option<Box<dyn ReadWrite + Send + Sync>>,
-    pub rx_event: EventFd,
-    pub rx_ctrl_event: EventFd,
+    pub rx_event: (EventConsumer, EventNotifier),
+    pub rx_ctrl_event: (EventConsumer, EventNotifier),
     pub exit_event: (EventConsumer, EventNotifier),
     mem: Option<GuestMemoryAtomic<GuestMemoryMmap>>,
 }
@@ -168,8 +167,10 @@ impl VhostUserConsoleBackend {
             stdin: None,
             stream: None,
             listener: None,
-            rx_event: EventFd::new(EFD_NONBLOCK).map_err(|_| Error::EventFdFailed)?,
-            rx_ctrl_event: EventFd::new(EFD_NONBLOCK).map_err(|_| Error::EventFdFailed)?,
+            rx_event: new_event_consumer_and_notifier(EventFlag::NONBLOCK)
+                .map_err(|_| Error::EventFdFailed)?,
+            rx_ctrl_event: new_event_consumer_and_notifier(EventFlag::NONBLOCK)
+                .map_err(|_| Error::EventFdFailed)?,
             exit_event: new_event_consumer_and_notifier(EventFlag::NONBLOCK)
                 .map_err(|_| Error::EventFdFailed)?,
             mem: None,
@@ -416,7 +417,7 @@ impl VhostUserConsoleBackend {
             self.handle_control_msg(request)?;
 
             // trigger a kick to the CTRL_RT_QUEUE
-            self.rx_ctrl_event.write(1).unwrap();
+            self.rx_ctrl_event.1.notify().unwrap();
 
             vring
                 .add_used(desc_chain.head_index(), reader.bytes_read() as u32)
@@ -500,7 +501,7 @@ impl VhostUserConsoleBackend {
 
     /// Set self's VringWorker.
     pub fn set_vring_worker(&self, vring_worker: Arc<VringEpollHandler<Arc<RwLock<Self>>>>) {
-        let rx_event_fd = self.rx_event.as_raw_fd();
+        let rx_event_fd = self.rx_event.0.as_raw_fd();
         vring_worker
             .register_listener(
                 rx_event_fd,
@@ -509,7 +510,7 @@ impl VhostUserConsoleBackend {
             )
             .unwrap();
 
-        let rx_ctrl_event_fd = self.rx_ctrl_event.as_raw_fd();
+        let rx_ctrl_event_fd = self.rx_ctrl_event.0.as_raw_fd();
         vring_worker
             .register_listener(
                 rx_ctrl_event_fd,
@@ -655,7 +656,7 @@ impl VhostUserConsoleBackend {
                     for byte in buffer.iter().take(bytes_read) {
                         self.rx_data_fifo.add(*byte).unwrap();
                     }
-                    self.rx_event.write(1).unwrap();
+                    self.rx_event.1.notify().unwrap();
                 }
             }
             Err(e) => {
@@ -680,7 +681,7 @@ impl VhostUserConsoleBackend {
                     // and trigger an EventFd.
                     if self.ready_to_write {
                         self.rx_data_fifo.add(bytes[0]).unwrap();
-                        self.rx_event.write(1).unwrap();
+                        self.rx_event.1.notify().unwrap();
                     }
                 }
                 Ok(())
@@ -825,11 +826,11 @@ impl VhostUserBackendMut for VhostUserConsoleBackend {
                     }
                     QueueEvents::CTRL_TX_QUEUE => self.process_ctrl_tx_queue(vring),
                     QueueEvents::BACKEND_RX_EFD => {
-                        let _ = self.rx_event.read();
+                        let _ = self.rx_event.0.consume();
                         self.process_rx_queue(vring)
                     }
                     QueueEvents::BACKEND_CTRL_RX_EFD => {
-                        let _ = self.rx_ctrl_event.read();
+                        let _ = self.rx_ctrl_event.0.consume();
                         self.process_ctrl_rx_queue(vring)
                     }
                     other => Err(Error::HandleEventUnknown(other)),
@@ -848,11 +849,11 @@ impl VhostUserBackendMut for VhostUserConsoleBackend {
                 QueueEvents::CTRL_RX_QUEUE => self.process_ctrl_rx_queue(vring),
                 QueueEvents::CTRL_TX_QUEUE => self.process_ctrl_tx_queue(vring),
                 QueueEvents::BACKEND_RX_EFD => {
-                    let _ = self.rx_event.read();
+                    let _ = self.rx_event.0.consume();
                     self.process_rx_queue(vring)
                 }
                 QueueEvents::BACKEND_CTRL_RX_EFD => {
-                    let _ = self.rx_ctrl_event.read();
+                    let _ = self.rx_ctrl_event.0.consume();
                     self.process_ctrl_rx_queue(vring)
                 }
                 other => Err(Error::HandleEventUnknown(other)),


### PR DESCRIPTION
This PR is to make vhost-user-console run on macOS.
QEMU: https://github.com/uran0sH/qemu
How to run:
QEMU:
```
qemu-system-aarch64 \
    -m 512M \
    -machine virt,memory-backend=mem \
    -accel hvf  \
    -cpu host \
    -nographic \
    -smp 4 \
    -kernel std-vmlinux-6.6.bin \
    -append "console=ttyAMA0 root=/dev/vda rw" \
    -drive if=none,id=image,file=openEuler-24.03-LTS-stratovirt-aarch64.img,format=raw \
    -device virtio-blk-device,drive=image \
    -object memory-backend-shm,id=mem,size=512M \
    -chardev socket,path=/tmp/console.sock0,id=con0             \
    -device vhost-user-console-pci,chardev=con0,id=console      \
    -serial stdio \
    -nodefaults
```
vhost-device-console:
```
vhost-device-console --socket-path=/tmp/console.sock --socket-count=1 \
                           --tcp-port=12345 --backend=network
```
terminal:
```
stty -icanon -echo && nc localhost 12345 && stty echo
```

Current status is that it can working on Linux. On macOS, After `stty -icanon -echo && nc localhost 12345 && stty echo`, I type one character which causes stuck

cc @germag @stefano-garzarella @osteffenrh